### PR TITLE
Converge instance and reduce cli noise

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,5 +16,10 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[kafka_broker::default]
+      - recipe[apt]
+      - recipe[zookeeper]
+      - recipe[zookeeper::service]
+      - recipe[kafka_broker]
     attributes:
+      zookeeper:
+        service_style: "upstart"

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,6 @@
 site :opscode
 
+cookbook "apt"
+cookbook 'zookeeper', git: 'git://github.com/SimpleFinance/chef-zookeeper.git'
+
 metadata

--- a/README.md
+++ b/README.md
@@ -17,6 +17,31 @@ Based off the work of [Federico Gimenez Nieto](https://github.com/fgimenez/kafka
 * `kafka_broker::service`
     - Create service upstart scripts
 
+## Usage
+
+Create a single kafka node with a single zookeeper instance on the same host.
+
+```bash
+bundle install --path vendor/bundle
+bundle exec berks install
+bundle exec kitchen converge
+bundle exec kitchen login
+```
+
+Login to the instance and create a new kafka topic with 3 partitions.
+
+```bash
+$ sudo /usr/local/kafka/bin/kafka-topics.sh --create --topic event-stream --replication-factor 1 --partitions 3 --zookeeper localhost:2181
+# [2015-02-06 00:49:08,721] INFO Topic creation {"version":1,"partitions":{"2":[0],"1":[0],"0":[0]}} (kafka.admin.AdminUtils$)
+# Created topic "event-stream".
+
+$ sudo /usr/local/kafka/bin/kafka-topics.sh --describe --zookeeper localhost:2181
+# Topic:event-stream  PartitionCount:3    ReplicationFactor:1 Configs:
+#     Topic: event-stream Partition: 0    Leader: 0   Replicas: 0 Isr: 0
+#     Topic: event-stream Partition: 1    Leader: 0   Replicas: 0 Isr: 0
+#     Topic: event-stream Partition: 2    Leader: 0   Replicas: 0 Isr: 0
+```
+
 ## Contributing
 
 * Standard PR model with details on why

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,8 +6,8 @@
 default["kafka_broker"]["version"] = "0.8.1.1"
 default["kafka_broker"]["scala_version"] = "2.10"
 default["kafka_broker"]["mirror"] = "http://apache.mirrors.tds.net/kafka"
-# shasum -a 256 /tmp/kitchen/cache/kafka_2.10-0.8.1.1.tgz | cut -c-6
-default["kafka_broker"]["checksum"] = "2532af"
+# shasum -a 256 /tmp/kitchen/cache/kafka_2.10-0.8.1.1.tgz
+default["kafka_broker"]["checksum"] = "2532af3dbd71d2f2f95f71abff5b7505690bd1f15c7063f8cbaa603b45ee4e86"
 
 default["kafka_broker"]["user"] = "kafka"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,6 +87,6 @@ default["kafka_broker"]["conf"]["log4j"] = {
     "log4j.logger.kafka.network.RequestChannel$" => "WARN, requestAppender",
     "log4j.logger.kafka.request.logger" => "WARN, requestAppender",
     "log4j.logger.state.change.logger" => "TRACE, stateChangeAppender",
-    "log4j.rootLogger" => "INFO, stdout "
+    "log4j.rootLogger" => "WARN, stdout "
   }
 }


### PR DESCRIPTION
- Take logging level down to WARN
- Fix checksum for kafka tarball
- Add zookeeper and apt to kitchen converge for a functional single instance
- Add usage notes to README

Test converge and verified topic creation

```
bundle install --path vendor/bundle
bundle exec berks install
bundle exec kitchen converge
bundle exec kitchen login

sudo /usr/local/kafka/bin/kafka-topics.sh --create --topic event-stream --replication-factor 1 --partitions 3 --zookeeper localhost:2181
# [2015-02-06 00:49:08,721] INFO Topic creation {"version":1,"partitions":{"2":[0],"1":[0],"0":[0]}} (kafka.admin.AdminUtils$)
# Created topic "event-stream".

sudo /usr/local/kafka/bin/kafka-topics.sh --describe --zookeeper localhost:2181
# Topic:event-stream  PartitionCount:3    ReplicationFactor:1 Configs:
#     Topic: event-stream Partition: 0    Leader: 0   Replicas: 0 Isr: 0
#     Topic: event-stream Partition: 1    Leader: 0   Replicas: 0 Isr: 0
#     Topic: event-stream Partition: 2    Leader: 0   Replicas: 0 Isr: 0
```
