### PR TITLE
Kafka 0.8.2.0 with topic deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache Kafka Cookbook
 
-Install and configure apache kafka 0.8.1.1.
+Install and configure apache kafka 0.8.2.0.
 
 Default installation assumes a local zookeeper instance (see [SimpleFinance/chef-zookeeper](https://github.com/SimpleFinance/chef-zookeeper)).
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,30 @@ bundle exec kitchen converge
 bundle exec kitchen login
 ```
 
-Login to the instance and create a new kafka topic with 3 partitions.
+**Create a new kafka topic with 3 partitions**
 
 ```bash
-$ sudo /usr/local/kafka/bin/kafka-topics.sh --create --topic event-stream --replication-factor 1 --partitions 3 --zookeeper localhost:2181
+sudo /usr/local/kafka/bin/kafka-topics.sh --create --topic event-stream --replication-factor 1 --partitions 3 --zookeeper localhost:2181
 # [2015-02-06 00:49:08,721] INFO Topic creation {"version":1,"partitions":{"2":[0],"1":[0],"0":[0]}} (kafka.admin.AdminUtils$)
 # Created topic "event-stream".
+```
 
-$ sudo /usr/local/kafka/bin/kafka-topics.sh --describe --zookeeper localhost:2181
+**Verify the new topic exists**
+
+```
+sudo /usr/local/kafka/bin/kafka-topics.sh --describe --zookeeper localhost:2181
 # Topic:event-stream  PartitionCount:3    ReplicationFactor:1 Configs:
 #     Topic: event-stream Partition: 0    Leader: 0   Replicas: 0 Isr: 0
 #     Topic: event-stream Partition: 1    Leader: 0   Replicas: 0 Isr: 0
 #     Topic: event-stream Partition: 2    Leader: 0   Replicas: 0 Isr: 0
+```
+
+**Delete the topic** (new feature)
+
+```
+sudo /usr/local/kafka/bin/kafka-topics.sh --delete --topic event-stream2  --zookeeper localhost:2181
+# Topic event-stream is marked for deletion.
+# Note: This will have no impact if delete.topic.enable is not set to true.
 ```
 
 ## Contributing

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,7 +44,8 @@ default["apache_kafka"]["conf"]["server"] = {
     # "default.replication.factor" => 2,
     #
     # For a full list reference kafka's config documentation
-    "log.dirs" => node["apache_kafka"]["log_dir"]
+    "log.dirs" => node["apache_kafka"]["log_dir"],
+    "delete.topic.enable" => "true"
   }
 }
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,11 +3,11 @@
 # Attribute:: default
 #
 
-default["apache_kafka"]["version"] = "0.8.1.1"
-default["apache_kafka"]["scala_version"] = "2.10"
+default["apache_kafka"]["version"] = "0.8.2.0"
+default["apache_kafka"]["scala_version"] = "2.11"
 default["apache_kafka"]["mirror"] = "http://apache.mirrors.tds.net/kafka"
-# shasum -a 256 /tmp/kitchen/cache/kafka_2.10-0.8.1.1.tgz
-default["apache_kafka"]["checksum"] = "2532af3dbd71d2f2f95f71abff5b7505690bd1f15c7063f8cbaa603b45ee4e86"
+# shasum -a 256 /tmp/kitchen/cache/kafka_2.11-0.8.2.0.tgz
+default["apache_kafka"]["checksum"] = "16df600d31b867fc4e33e1132b6cb502ba0d24a173437abef206ced1a2044b62"
 
 default["apache_kafka"]["user"] = "kafka"
 


### PR DESCRIPTION
Update attributes to install kafka 0.8.2.0 by default.

[KAFKA-1397](https://issues.apache.org/jira/browse/KAFKA-1397) "delete topic is not working" resolved in 0.8.2.0 so enabling in server.config by default and adding to example in README.md.
