### PR TITLE
Bump to kafka 0.8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache Kafka Cookbook
 
-Install and configure apache kafka 0.8.2.0.
+Install and configure apache kafka 0.8.2.1.
 
 Default installation assumes a local zookeeper instance (see [SimpleFinance/chef-zookeeper](https://github.com/SimpleFinance/chef-zookeeper)).
 
@@ -47,10 +47,10 @@ sudo /usr/local/kafka/bin/kafka-topics.sh --describe --zookeeper localhost:2181
 #     Topic: event-stream Partition: 2    Leader: 0   Replicas: 0 Isr: 0
 ```
 
-**Delete the topic** (new feature)
+**Delete the topic**
 
 ```
-sudo /usr/local/kafka/bin/kafka-topics.sh --delete --topic event-stream2  --zookeeper localhost:2181
+sudo /usr/local/kafka/bin/kafka-topics.sh --delete --topic event-stream --zookeeper localhost:2181
 # Topic event-stream is marked for deletion.
 # Note: This will have no impact if delete.topic.enable is not set to true.
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,11 +3,11 @@
 # Attribute:: default
 #
 
-default["apache_kafka"]["version"] = "0.8.2.0"
+default["apache_kafka"]["version"] = "0.8.2.1"
 default["apache_kafka"]["scala_version"] = "2.11"
 default["apache_kafka"]["mirror"] = "http://apache.mirrors.tds.net/kafka"
-# shasum -a 256 /tmp/kitchen/cache/kafka_2.11-0.8.2.0.tgz
-default["apache_kafka"]["checksum"] = "16df600d31b867fc4e33e1132b6cb502ba0d24a173437abef206ced1a2044b62"
+# shasum -a 256 /tmp/kitchen/cache/kafka_2.11-0.8.2.1.tgz
+default["apache_kafka"]["checksum"] = "9fb84546149b477bdbf167da8ca880a2c1199aeb24b2d5cd17aac0973ba4e54b"
 
 default["apache_kafka"]["user"] = "kafka"
 


### PR DESCRIPTION
Bumping default apache kafka version to 0.8.2.1

4 bug fixes
[RELEASE_NOTES](https://archive.apache.org/dist/kafka/0.8.2.1/RELEASE_NOTES.html)
