### PR TITLE
Optionally separate log and data directories

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@ default["apache_kafka"]["kafka_heap_opts"] = "-Xmx512M -Xms256M"
 default["apache_kafka"]["install_java"] = true
 
 default["apache_kafka"]["install_dir"] = "/usr/local/kafka"
+default["apache_kafka"]["data_dir"] = "/var/log/kafka"
 default["apache_kafka"]["log_dir"] = "/var/log/kafka"
 default["apache_kafka"]["bin_dir"] = "/usr/local/kafka/bin"
 default["apache_kafka"]["config_dir"] = "/usr/local/kafka/config"
@@ -44,7 +45,7 @@ default["apache_kafka"]["conf"]["server"] = {
     # "default.replication.factor" => 2,
     #
     # For a full list reference kafka's config documentation
-    "log.dirs" => node["apache_kafka"]["log_dir"],
+    "log.dirs" => node["apache_kafka"]["data_dir"],
     "delete.topic.enable" => "true"
   }
 }

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -6,6 +6,7 @@
 [
   node["apache_kafka"]["config_dir"],
   node["apache_kafka"]["bin_dir"],
+  node["apache_kafka"]["data_dir"],
   node["apache_kafka"]["log_dir"],
 ].each do |dir|
   directory dir do
@@ -22,8 +23,7 @@ end
     mode "0755"
     variables(
       :config_dir => node["apache_kafka"]["config_dir"],
-      :bin_dir => node["apache_kafka"]["bin_dir"],
-      :log_dir => node["apache_kafka"]["log_dir"]
+      :bin_dir => node["apache_kafka"]["bin_dir"]
     )
     notifies :restart, "service[kafka]", :delayed
   end

--- a/templates/default/kafka_env.erb
+++ b/templates/default/kafka_env.erb
@@ -8,7 +8,6 @@ export SCALA_VERSION="<%= @scala_version %>"
 # Directories
 export KAFKA_CONFIG="<%= @kafka_config %>"
 export KAFKA_BIN="<%= @kafka_bin %>"
-export KAFKA_LOG_DIR="<%= @kafka_log %>"
 
 # Which java to use
 if [ -z "$JAVA_HOME" ]; then
@@ -30,7 +29,7 @@ if [ ! -z $JMX_PORT ]; then
 fi
 
 # Log4j settings
-export KAFKA_LOG4J_OPTS="-Dkafka.logs.dir=$KAFKA_LOG_DIR -Dlog4j.configuration=file:${KAFKA_CONFIG}/log4j.properties"
+export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${KAFKA_CONFIG}/log4j.properties"
 
 # Generic jvm settings you want to add
 export KAFKA_OPTS=""


### PR DESCRIPTION
- server logs written to `node["apache_kafka"]["log_dir"]`
- kafka data files `node["apache_kafka"]["data_dir"]`
