### PR TITLE
Modifying metadata to include info on valid kafka versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ name             "apache_kafka"
 maintainer       "Daniel Couture"
 maintainer_email "mathyourlife@gmail.com"
 license          "Apache-2.0"
-description      "Installs/Configures Apache Kafka broker"
+description      "Installs/Configures Apache Kafka >= 0.7.0"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          IO.read(File.join(File.dirname(__FILE__), "VERSION")) rescue "0.0.1"
 


### PR DESCRIPTION
Adding this note may help distinguish between pre Apache and post Apache cookbooks in `knife cookbook site search kafka`
