### PR TITLE
Paramaterize script list

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,8 @@ default["apache_kafka"]["broker.id"] = nil
 default["apache_kafka"]["port"] = 9092
 default["apache_kafka"]["zookeeper.connect"] = nil
 
-default["apache_kafka"]["install_scripts"] = %w{ kafka-server-start.sh kafka-run-class.sh kafka-topics.sh }
+default["apache_kafka"]["install_scripts"] = %w{ kafka-run-class.sh }
+default["apache_kafka"]["template_scripts"] = %w{ kafka-server-start.sh kafka-topics.sh }
 
 # Check in /var/log/kafka/server.log for invalid entries
 #

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,8 @@ default["apache_kafka"]["broker.id"] = nil
 default["apache_kafka"]["port"] = 9092
 default["apache_kafka"]["zookeeper.connect"] = nil
 
+default["apache_kafka"]["install_scripts"] = %w{ kafka-server-start.sh kafka-run-class.sh kafka-topics.sh }
+
 # Check in /var/log/kafka/server.log for invalid entries
 #
 default["apache_kafka"]["conf"]["server"] = {

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -15,7 +15,7 @@
   end
 end
 
-node["install_scripts"].each do |bin|
+node["apache_kafka"]["install_scripts"].each do |bin|
   template ::File.join(node["apache_kafka"]["bin_dir"], bin) do
     source "bin/#{bin}.erb"
     owner "kafka"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -3,18 +3,6 @@
 # Recipe:: configure
 #
 
-[
-  node["apache_kafka"]["config_dir"],
-  node["apache_kafka"]["bin_dir"],
-  node["apache_kafka"]["data_dir"],
-  node["apache_kafka"]["log_dir"],
-].each do |dir|
-  directory dir do
-    recursive true
-    owner node["apache_kafka"]["user"]
-  end
-end
-
 node["apache_kafka"]["template_scripts"].each do |bin|
   template ::File.join(node["apache_kafka"]["bin_dir"], bin) do
     source "bin/#{bin}.erb"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -15,7 +15,7 @@
   end
 end
 
-%w{ kafka-server-start.sh kafka-run-class.sh kafka-topics.sh }.each do |bin|
+node["install_scripts"].each do |bin|
   template ::File.join(node["apache_kafka"]["bin_dir"], bin) do
     source "bin/#{bin}.erb"
     owner "kafka"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -15,7 +15,7 @@
   end
 end
 
-node["apache_kafka"]["install_scripts"].each do |bin|
+node["apache_kafka"]["template_scripts"].each do |bin|
   template ::File.join(node["apache_kafka"]["bin_dir"], bin) do
     source "bin/#{bin}.erb"
     owner "kafka"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -36,7 +36,6 @@ execute "unzip kafka source" do
 end
 
 node["apache_kafka"]["install_scripts"].each do |bin|
-  execute "copy ${bin}" do
     remote_file "Copy service file" do
       path "${bin_dir}/${bin}"
       source "file://${source_path}/bin/${bin}"
@@ -44,6 +43,5 @@ node["apache_kafka"]["install_scripts"].each do |bin|
       group 'root'
       mode 0755
     end
-  end
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -37,8 +37,8 @@ end
 
 node["apache_kafka"]["install_scripts"].each do |bin|
     remote_file "Copy service file" do
-      path "${bin_dir}/${bin}"
-      source "file://${source_path}/bin/${bin}"
+      path "#{bin_dir}/#{bin}"
+      source "file://#{source_path}/bin/#{bin}"
       owner 'root'
       group 'root'
       mode 0755

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -59,6 +59,8 @@ node["apache_kafka"]["install_scripts"].each do |bin|
       owner 'root'
       group 'root'
       mode 0755
+      action :nothing
+      subscribes :create, "execute[unzip kafka source]", :immediately
     end
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -53,7 +53,7 @@ execute "unzip kafka source" do
 end
 
 node["apache_kafka"]["install_scripts"].each do |bin|
-    remote_file "Copy service file" do
+    remote_file "Copy service file #{bin}" do
       path "#{bin_dir}/#{bin}"
       source "file://#{source_path}/bin/#{bin}"
       owner 'root'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -8,6 +8,8 @@ include_recipe "java" if node["apache_kafka"]["install_java"]
 version_tag = "kafka_#{node["apache_kafka"]["scala_version"]}-#{node["apache_kafka"]["version"]}"
 download_url = ::File.join(node["apache_kafka"]["mirror"], "#{node["apache_kafka"]["version"]}/#{version_tag}.tgz")
 download_path = ::File.join(Chef::Config[:file_cache_path], "#{version_tag}.tgz")
+source_path = ::File.join(node["apache_kafka"]["install_dir"], version_tag)
+bin_dir = node["apache_kafka"]["bin_dir"]
 
 user node["apache_kafka"]["user"] do
   comment node["apache_kafka"]["user"]
@@ -30,5 +32,18 @@ end
 
 execute "unzip kafka source" do
   command "tar -zxvf #{download_path} -C #{node["apache_kafka"]["install_dir"]}"
-  not_if { ::File.exist?(::File.join(node["apache_kafka"]["install_dir"], version_tag)) }
+  not_if { ::File.exist?(source_path) }
 end
+
+node["apache_kafka"]["install_scripts"].each do |bin|
+  execute "copy ${bin}" do
+    remote_file "Copy service file" do
+      path "${bin_dir}/${bin}"
+      source "file://${source_path}/bin/${bin}"
+      owner 'root'
+      group 'root'
+      mode 0755
+    end
+  end
+end
+

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -9,7 +9,24 @@ version_tag = "kafka_#{node["apache_kafka"]["scala_version"]}-#{node["apache_kaf
 download_url = ::File.join(node["apache_kafka"]["mirror"], "#{node["apache_kafka"]["version"]}/#{version_tag}.tgz")
 download_path = ::File.join(Chef::Config[:file_cache_path], "#{version_tag}.tgz")
 source_path = ::File.join(node["apache_kafka"]["install_dir"], version_tag)
+
+config_dir = node["apache_kafka"]["config_dir"]
 bin_dir = node["apache_kafka"]["bin_dir"]
+data_dir = node["apache_kafka"]["data_dir"]
+log_dir = node["apache_kafka"]["log_dir"]
+
+[
+  config_dir,
+  bin_dir,
+  data_dir,
+  log_dir,
+].each do |dir|
+  directory dir do
+    recursive true
+    owner node["apache_kafka"]["user"]
+  end
+end
+
 
 user node["apache_kafka"]["user"] do
   comment node["apache_kafka"]["user"]

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -15,6 +15,13 @@ bin_dir = node["apache_kafka"]["bin_dir"]
 data_dir = node["apache_kafka"]["data_dir"]
 log_dir = node["apache_kafka"]["log_dir"]
 
+
+user node["apache_kafka"]["user"] do
+  comment node["apache_kafka"]["user"]
+  system true
+  shell "/bin/false"
+end
+
 [
   config_dir,
   bin_dir,
@@ -25,13 +32,6 @@ log_dir = node["apache_kafka"]["log_dir"]
     recursive true
     owner node["apache_kafka"]["user"]
   end
-end
-
-
-user node["apache_kafka"]["user"] do
-  comment node["apache_kafka"]["user"]
-  system true
-  shell "/bin/false"
 end
 
 directory node["apache_kafka"]["install_dir"] do


### PR DESCRIPTION
I'd like to install more scripts than this, but I'm happy to set that in a wrapper cookbook or via node / override attributes.

This change results in the same output as the previous code, but allows for a list of scripts to copy to be configured by others with no code change.
