### PR TITLE
/etc/default/kafka doubly sourced

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,3 +41,6 @@ suites:
     attributes:
       apt:
         compile_time_update: true
+      apache_kafka:
+        jmx:
+          port: 9093

--- a/templates/default/bin/kafka-run-class.sh.erb
+++ b/templates/default/bin/kafka-run-class.sh.erb
@@ -20,8 +20,6 @@ then
   exit 1
 fi
 
-source /etc/default/kafka
-
 while [ $# -gt 0 ]; do
   COMMAND=$1
   case $COMMAND in

--- a/templates/default/bin/kafka-server-start.sh.erb
+++ b/templates/default/bin/kafka-server-start.sh.erb
@@ -20,8 +20,6 @@ then
   exit 1
 fi
 
-source /etc/default/kafka
-
 EXTRA_ARGS="-name kafkaServer -loggc"
 
 COMMAND=$1

--- a/templates/default/bin/kafka-topics.sh.erb
+++ b/templates/default/bin/kafka-topics.sh.erb
@@ -14,6 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /etc/default/kafka
-
 exec <%= @bin_dir %>/kafka-run-class.sh kafka.admin.TopicCommand $@

--- a/test/integration/default/serverspec/service_spec.rb
+++ b/test/integration/default/serverspec/service_spec.rb
@@ -9,6 +9,10 @@ describe "Kafka broker" do
     expect(port(9092)).to be_listening
   end
 
+  it "is listening on port 9093" do
+    expect(port(9093)).to be_listening
+  end
+
   it "has a running service of kafka" do
     expect(service("kafka")).to be_running
   end


### PR DESCRIPTION
Bug fix:
- `/etc/default/kafka` was being sourced in the init script then again at the executable bash level.  Removing the source in the bash scripts can allow users more flexibility in overriding environmental variables.

Added:
- Server spec test to verify jmx port is listening
