### PR TITLE
Allow overriding data_dir in wrapper cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,6 @@ default["apache_kafka"]["conf"]["server"] = {
     # "default.replication.factor" => 2,
     #
     # For a full list reference kafka's config documentation
-    "log.dirs" => node["apache_kafka"]["data_dir"],
     "delete.topic.enable" => "true"
   }
 }

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -45,6 +45,7 @@ template ::File.join(node["apache_kafka"]["config_dir"],
     :broker_id => broker_id,
     :port => node["apache_kafka"]["port"],
     :zookeeper_connect => zookeeper_connect,
+    :log_dirs => node["apache_kafka"]["data_dir"],
     :entries => node["apache_kafka"]["conf"]["server"]["entries"]
   )
   notifies :restart, "service[kafka]", :delayed

--- a/templates/default/properties/server.properties.erb
+++ b/templates/default/properties/server.properties.erb
@@ -4,6 +4,7 @@
 broker.id=<%= @broker_id %>
 port=<%= @port %>
 zookeeper.connect=<%= @zookeeper_connect %>
+log.dirs=<%= @log_dirs %>
 
 <%- @entries.each do |k, v| %>
 <%= k %>=<%= v %>


### PR DESCRIPTION
Overriding node["apache_kafka"]["data_dir"] in a wrapper cookbook does
not work, because node["apache_kafka"]["conf"]["server"] is computed too
early, and subsequent changes no longer take effect, so the wrong
location ends up in server.properties.

To fix, treat the log.dirs setting in server.properties explicitly,
instead of as part of the "entries" group.
