### PR TITLE
Multiple Changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,15 @@
+AllCops:
+  Exclude:
+    - Rakefile
+    - Berksfile
+    - Vagrantfile
+    - Thorfile
+    - Gemfile
+    - metadata.rb
+    - '.kitchen/*'
+    - 'spec/**/*'
+    - 'vendor/**/*'
+    - 'test/**/*'
 StringLiterals:
   EnforcedStyle: double_quotes
 HashSyntax:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ default["apache_kafka"]["version"] = "0.8.2.1"
 default["apache_kafka"]["scala_version"] = "2.11"
 default["apache_kafka"]["mirror"] = "http://apache.mirrors.tds.net/kafka"
 # shasum -a 256 /tmp/kitchen/cache/kafka_2.11-0.8.2.1.tgz
-default["apache_kafka"]["checksum"] = "9fb84546149b477bdbf167da8ca880a2c1199aeb24b2d5cd17aac0973ba4e54b"
+default["apache_kafka"]["checksum"]["0.8.2.1"] = "9fb84546149b477bdbf167da8ca880a2c1199aeb24b2d5cd17aac0973ba4e54b"
 
 default["apache_kafka"]["user"] = "kafka"
 default["apache_kafka"]["setup_user"] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default["apache_kafka"]["mirror"] = "http://apache.mirrors.tds.net/kafka"
 default["apache_kafka"]["checksum"] = "9fb84546149b477bdbf167da8ca880a2c1199aeb24b2d5cd17aac0973ba4e54b"
 
 default["apache_kafka"]["user"] = "kafka"
+default["apache_kafka"]["setup_user"] = true
 
 # heap options are set low to allow for local development
 default["apache_kafka"]["kafka_heap_opts"] = "-Xmx512M -Xms256M"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -7,7 +7,7 @@
   node["apache_kafka"]["config_dir"],
   node["apache_kafka"]["bin_dir"],
   node["apache_kafka"]["data_dir"],
-  node["apache_kafka"]["log_dir"],
+  node["apache_kafka"]["log_dir"]
 ].each do |dir|
   directory dir do
     recursive true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -24,7 +24,7 @@ end
 remote_file download_path do
   source download_url
   backup false
-  checksum node["apache_kafka"]["checksum"]
+  checksum node["apache_kafka"]["checksum"][node["apache_kafka"]["version"]]
   notifies :run, "execute[unzip kafka source]"
   not_if { ::File.exist?(::File.join(node["apache_kafka"]["install_dir"], version_tag)) }
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -5,8 +5,8 @@
 
 include_recipe "java" if node["apache_kafka"]["install_java"]
 
-version_tag = "kafka_#{node["apache_kafka"]["scala_version"]}-#{node["apache_kafka"]["version"]}"
-download_url = ::File.join(node["apache_kafka"]["mirror"], "#{node["apache_kafka"]["version"]}/#{version_tag}.tgz")
+version_tag = "kafka_#{node['apache_kafka']['scala_version']}-#{node['apache_kafka']['version']}"
+download_url = ::File.join(node["apache_kafka"]["mirror"], "#{node['apache_kafka']['version']}/#{version_tag}.tgz")
 download_path = ::File.join(Chef::Config[:file_cache_path], "#{version_tag}.tgz")
 
 user node["apache_kafka"]["user"] do
@@ -30,6 +30,6 @@ remote_file download_path do
 end
 
 execute "unzip kafka source" do
-  command "tar -zxvf #{download_path} -C #{node["apache_kafka"]["install_dir"]}"
+  command "tar -zxvf #{download_path} -C #{node['apache_kafka']['install_dir']}"
   not_if { ::File.exist?(::File.join(node["apache_kafka"]["install_dir"], version_tag)) }
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -13,6 +13,7 @@ user node["apache_kafka"]["user"] do
   comment node["apache_kafka"]["user"]
   system true
   shell "/bin/false"
+  only_if { node["apache_kafka"]["setup_user"] }
 end
 
 directory node["apache_kafka"]["install_dir"] do

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version_tag = "kafka_#{node["apache_kafka"]["scala_version"]}-#{node["apache_kafka"]["version"]}"
+version_tag = "kafka_#{node['apache_kafka']['scala_version']}-#{node['apache_kafka']['version']}"
 
 template "/etc/default/kafka" do
   source "kafka_env.erb"
@@ -68,9 +68,9 @@ when "init.d"
     action [:start]
   end
 when "runit"
-  include_recipe 'runit'
+  include_recipe "runit"
 
-  runit_service 'kafka' do
+  runit_service "kafka" do
     default_logger true
     action [:enable, :start]
   end


### PR DESCRIPTION
- user setup is now optional, but enabled by default. one can disable the user setup and can use a separate user cookbook
- fixed rubocop check and updated `.rubocop.yml` to exclude generic directories/files
- `default["apache_kafka"]["checksum"]` is now a hash of versions checksum, gives user the capability to use any supported version without setting the version checksum value

hope it helps, let me know if PR looks good.
