### PR TITLE
Avoid writing lots of log output to stdout by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,7 @@ default["apache_kafka"]["conf"]["server"] = {
 default["apache_kafka"]["conf"]["log4j"] = {
   "file" => "log4j.properties",
   "entries" => {
+    "log4j.additivity.kafka" => "false",
     "log4j.additivity.kafka.controller" => "false",
     "log4j.additivity.kafka.log.LogCleaner" => "false",
     "log4j.additivity.kafka.network.RequestChannel$" => "false",


### PR DESCRIPTION
With the provided default log4j configuration, everything written to server.log also ends up on stdout, which seems useless and potentially annoying.  Set log4j.additivity.kafka to false to avoid that.

(I suppose the original configuration has been copied out of the kafka source tarball, which also contains this issue.)
