### PR TITLE
Allow modifying jvm options via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,8 @@ default["apache_kafka"]["setup_user"] = true
 
 # heap options are set low to allow for local development
 default["apache_kafka"]["kafka_heap_opts"] = "-Xmx512M -Xms256M"
+default["apache_kafka"]["kafka_jvm_performance_opts"] = "-server -XX:+UseCompressedOops -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+DisableExplicitGC -Djava.awt.headless=true"
+default["apache_kafka"]["kafka_opts"] = ""
 
 default["apache_kafka"]["jmx"]["port"] = ""
 default["apache_kafka"]["jmx"]["opts"] = "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -32,6 +32,8 @@ template "/etc/default/kafka" do
     :kafka_user => node["apache_kafka"]["user"],
     :scala_version => node["apache_kafka"]["scala_version"],
     :kafka_heap_opts => node["apache_kafka"]["kafka_heap_opts"],
+    :kafka_jvm_performance_opts => node["apache_kafka"]["kafka_jvm_performance_opts"],
+    :kafka_opts => node["apache_kafka"]["kafka_opts"],
     :jmx_port => node["apache_kafka"]["jmx"]["port"],
     :jmx_opts => node["apache_kafka"]["jmx"]["opts"]
   )

--- a/templates/default/kafka_env.erb
+++ b/templates/default/kafka_env.erb
@@ -32,13 +32,13 @@ fi
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${KAFKA_CONFIG}/log4j.properties"
 
 # Generic jvm settings you want to add
-export KAFKA_OPTS=""
+export KAFKA_OPTS="<%= @kafka_opts %>"
 
 # Memory options
 export KAFKA_HEAP_OPTS="<%= @kafka_heap_opts %>"
 
 # JVM performance options
-export KAFKA_JVM_PERFORMANCE_OPTS="-server -XX:+UseCompressedOops -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+DisableExplicitGC -Djava.awt.headless=true"
+export KAFKA_JVM_PERFORMANCE_OPTS="<%= @kafka_jvm_performance_opts %>"
 
 ##### CLASSPATH
 


### PR DESCRIPTION
Allows modification of jvm options in /etc/defaults/kafka via attributes. Will not modify behavior unless attributes are overridden.
