### PR TITLE
Make umask configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,8 @@ default["apache_kafka"]["bin_dir"] = "/usr/local/kafka/bin"
 default["apache_kafka"]["config_dir"] = "/usr/local/kafka/config"
 
 default["apache_kafka"]["service_style"] = "upstart"
+# Currently only for upstart, the umask for the kafka server process
+default["apache_kafka"]["umask"] = 007
 
 # Kafka configuration settings are detailed here.
 # https://kafka.apache.org/08/configuration.html

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -48,6 +48,9 @@ when "upstart"
     group "root"
     action :create
     mode "0644"
+    variables(
+      :kafka_umask => sprintf("%#03o", node["apache_kafka"]["umask"])
+    )
     notifies :restart, "service[kafka]", :delayed
   end
   service "kafka" do

--- a/templates/default/kafka.init.erb
+++ b/templates/default/kafka.init.erb
@@ -9,7 +9,7 @@ stop on starting rc RUNLEVEL=[016]
 respawn
 respawn limit 2 5
 
-umask 007
+umask <%= @kafka_umask %>
 
 kill timeout 300
 


### PR DESCRIPTION
We have a monitoring process pick up the (0.9-style) broker id from the metadata for health checks and Consul service registration. The hardcoded umask of 007 was too restrictive for this, so this PR lets users override it.
