### PR TITLE
Ensure KAFKA_LOG_DIR is set

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -30,6 +30,7 @@ template "/etc/default/kafka" do
     :kafka_config => node["apache_kafka"]["config_dir"],
     :kafka_bin => node["apache_kafka"]["bin_dir"],
     :kafka_user => node["apache_kafka"]["user"],
+    :kafka_log_dir => node["apache_kafka"]["log_dir"],
     :scala_version => node["apache_kafka"]["scala_version"],
     :kafka_heap_opts => node["apache_kafka"]["kafka_heap_opts"],
     :kafka_jvm_performance_opts => node["apache_kafka"]["kafka_jvm_performance_opts"],

--- a/templates/default/kafka_env.erb
+++ b/templates/default/kafka_env.erb
@@ -4,6 +4,7 @@
 export KAFKA_USER="<%= @kafka_user %>"
 export KAFKA_HOME="<%= @kafka_home %>"
 export SCALA_VERSION="<%= @scala_version %>"
+export KAFKA_LOG_DIR="<%= @kafka_log_dir %>"
 
 # Directories
 export KAFKA_CONFIG="<%= @kafka_config %>"


### PR DESCRIPTION
The `kafka-run-class.sh` script needs this env var set in order to properly set the location of the GC log. E.g.,

``` bash
KAFKA_GC_LOG_OPTS="-Xloggc:$KAFKA_LOG_DIR/$GC_LOG_FILE_NAME
```

This can be avoided by setting $GC_LOG_ENABLED to false, but that does not appear to be the default setting, so this is needed.
