### PR TITLE
Make restart-notify configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,9 @@ default["apache_kafka"]["bin_dir"] = "/usr/local/kafka/bin"
 default["apache_kafka"]["config_dir"] = "/usr/local/kafka/config"
 
 default["apache_kafka"]["service_style"] = "upstart"
+# Set this to false if you don't want to automatically restart brokers when
+# the configuration changes.
+default["apache_kafka"]["restart_on_change"] = true
 # Currently only for upstart, the umask for the kafka server process
 default["apache_kafka"]["umask"] = 007
 

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -15,6 +15,8 @@
   end
 end
 
+do_restart = node['apache_kafka']['restart_on_change']
+
 %w{ kafka-server-start.sh kafka-run-class.sh kafka-topics.sh }.each do |bin|
   template ::File.join(node["apache_kafka"]["bin_dir"], bin) do
     source "bin/#{bin}.erb"
@@ -25,7 +27,7 @@ end
       :config_dir => node["apache_kafka"]["config_dir"],
       :bin_dir => node["apache_kafka"]["bin_dir"]
     )
-    notifies :restart, "service[kafka]", :delayed
+    notifies :restart, "service[kafka]", :delayed if do_restart
   end
 end
 
@@ -48,7 +50,7 @@ template ::File.join(node["apache_kafka"]["config_dir"],
     :log_dirs => node["apache_kafka"]["data_dir"],
     :entries => node["apache_kafka"]["conf"]["server"]["entries"]
   )
-  notifies :restart, "service[kafka]", :delayed
+  notifies :restart, "service[kafka]", :delayed if do_restart
 end
 
 template ::File.join(node["apache_kafka"]["config_dir"],
@@ -61,5 +63,5 @@ template ::File.join(node["apache_kafka"]["config_dir"],
     :log_dir => node["apache_kafka"]["log_dir"],
     :entries => node["apache_kafka"]["conf"]["log4j"]["entries"]
   )
-  notifies :restart, "service[kafka]", :delayed
+  notifies :restart, "service[kafka]", :delayed if do_restart
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 
 version_tag = "kafka_#{node['apache_kafka']['scala_version']}-#{node['apache_kafka']['version']}"
+do_restart = node['apache_kafka']['restart_on_change']
 
 template "/etc/default/kafka" do
   source "kafka_env.erb"
@@ -37,7 +38,7 @@ template "/etc/default/kafka" do
     :jmx_port => node["apache_kafka"]["jmx"]["port"],
     :jmx_opts => node["apache_kafka"]["jmx"]["opts"]
   )
-  notifies :restart, "service[kafka]", :delayed
+  notifies :restart, "service[kafka]", :delayed if do_restart
 end
 
 case node["apache_kafka"]["service_style"]
@@ -51,7 +52,7 @@ when "upstart"
     variables(
       :kafka_umask => sprintf("%#03o", node["apache_kafka"]["umask"])
     )
-    notifies :restart, "service[kafka]", :delayed
+    notifies :restart, "service[kafka]", :delayed if do_restart
   end
   service "kafka" do
     provider Chef::Provider::Service::Upstart
@@ -65,7 +66,7 @@ when "init.d"
     group "root"
     action :create
     mode "0744"
-    notifies :restart, "service[kafka]", :delayed
+    notifies :restart, "service[kafka]", :delayed if do_restart
   end
   service "kafka" do
     provider Chef::Provider::Service::Init


### PR DESCRIPTION
We prefer to roll Chef and then manually do a rolling restart of
our clusters. It's a bit more work but prevents funny hiccups. This
patch adds a setting to make restarting configurable.
